### PR TITLE
feat: add STM32H723 support, Scylla and Manta M8P V2.0 board configs,       and complete HAL class refactor for UART, SDIO and SPI SD card

### DIFF
--- a/STM32H723VGTX_BL_FLASH.ld
+++ b/STM32H723VGTX_BL_FLASH.ld
@@ -1,0 +1,176 @@
+/*
+******************************************************************************
+**
+**  File        : LinkerScript.ld
+**
+**  Author      : STM32CubeIDE
+**
+**  Abstract    : Linker script for STM32H7 series
+**                1024Kbytes FLASH and 560Kbytes RAM
+**
+**                Set heap size, stack size and stack location according
+**                to application requirements.
+**
+**                Set memory bank area and size if external memory is used.
+**
+**  Target      : STMicroelectronics STM32
+**
+**  Distribution: The file is distributed as is, without any warranty
+**                of any kind.
+**
+*****************************************************************************
+** @attention
+**
+** Copyright (c) 2022 STMicroelectronics.
+** All rights reserved.
+**
+** This software is licensed under terms that can be found in the LICENSE file
+** in the root directory of this software component.
+** If no LICENSE file comes with this software, it is provided AS-IS.
+**
+****************************************************************************
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = ORIGIN(RAM_D1) + LENGTH(RAM_D1);    /* end of RAM */
+/* Generate a link error if heap and stack don't fit into RAM */
+_Min_Heap_Size = 0x200;      /* required amount of heap  */
+_Min_Stack_Size = 0x400; /* required amount of stack */
+
+/* Specify the memory areas */
+MEMORY
+{
+  FLASH (rx)        : ORIGIN = 0x08020000, LENGTH = 1024K - 128K
+  DTCMRAM (xrw)     : ORIGIN = 0x20000000, LENGTH = 128K
+  RAM_D1 (xrw)      : ORIGIN = 0x24000000, LENGTH = 320K 
+  RAM_D2 (xrw)      : ORIGIN = 0x30000000, LENGTH = 32K
+  RAM_D3 (xrw)      : ORIGIN = 0x38000000, LENGTH = 16K
+  ITCMRAM (xrw)     : ORIGIN = 0x00000000, LENGTH = 64K
+}
+
+_FLASH_VectorTable = ORIGIN(FLASH);
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  /* Constant data goes into FLASH */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+  .ARM : {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  .preinit_array     :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >FLASH
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >FLASH
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >FLASH
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data :
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+    *(.RamFunc)        /* .RamFunc sections */
+    *(.RamFunc*)       /* .RamFunc* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM_D1 AT> FLASH
+
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM_D1
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM_D1
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/STM32H723VGTX_FLASH.ld
+++ b/STM32H723VGTX_FLASH.ld
@@ -1,0 +1,176 @@
+/*
+******************************************************************************
+**
+**  File        : LinkerScript.ld
+**
+**  Author      : STM32CubeIDE
+**
+**  Abstract    : Linker script for STM32H7 series
+**                1024Kbytes FLASH and 560Kbytes RAM
+**
+**                Set heap size, stack size and stack location according
+**                to application requirements.
+**
+**                Set memory bank area and size if external memory is used.
+**
+**  Target      : STMicroelectronics STM32
+**
+**  Distribution: The file is distributed as is, without any warranty
+**                of any kind.
+**
+*****************************************************************************
+** @attention
+**
+** Copyright (c) 2022 STMicroelectronics.
+** All rights reserved.
+**
+** This software is licensed under terms that can be found in the LICENSE file
+** in the root directory of this software component.
+** If no LICENSE file comes with this software, it is provided AS-IS.
+**
+****************************************************************************
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = ORIGIN(RAM_D1) + LENGTH(RAM_D1);    /* end of RAM */
+/* Generate a link error if heap and stack don't fit into RAM */
+_Min_Heap_Size = 0x200;      /* required amount of heap  */
+_Min_Stack_Size = 0x400; /* required amount of stack */
+
+/* Specify the memory areas */
+MEMORY
+{
+  FLASH (rx)        : ORIGIN = 0x08000000, LENGTH = 1024K
+  DTCMRAM (xrw)     : ORIGIN = 0x20000000, LENGTH = 128K
+  RAM_D1 (xrw)      : ORIGIN = 0x24000000, LENGTH = 320K 
+  RAM_D2 (xrw)      : ORIGIN = 0x30000000, LENGTH = 32K
+  RAM_D3 (xrw)      : ORIGIN = 0x38000000, LENGTH = 16K
+  ITCMRAM (xrw)     : ORIGIN = 0x00000000, LENGTH = 64K
+}
+
+_FLASH_VectorTable = ORIGIN(FLASH);
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  /* Constant data goes into FLASH */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+  .ARM : {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  .preinit_array     :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >FLASH
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >FLASH
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >FLASH
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data :
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+    *(.RamFunc)        /* .RamFunc sections */
+    *(.RamFunc*)       /* .RamFunc* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM_D1 AT> FLASH
+
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM_D1
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM_D1
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/Src/irqHandlers.h
+++ b/Src/irqHandlers.h
@@ -6,37 +6,84 @@
 
 extern "C" {
 
-    void EXTI4_IRQHandler() {
-        if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_4) != RESET) {
+    /* ── SPI chip-select interrupt ───────────────────────────────────────────
+     * The CS pin and its EXTI line are board-specific:
+     *
+     *   SKR3:           PA4  → EXTI4        → EXTI4_IRQHandler
+     *   Manta M8P V2.0: PA15 → EXTI15_10   → EXTI15_10_IRQHandler
+     *
+     * SPI_CS_IRQ is set per-board in platformio.ini:
+     *   -D SPI_CS_IRQ=EXTI4_IRQn           (SKR3)
+     *   -D SPI_CS_IRQ=EXTI15_10_IRQn       (Manta)
+     *
+     * The GPIO pin mask is derived from SPI_CS_IRQ to avoid a second
+     * board-specific define.
+     * ─────────────────────────────────────────────────────────────────────── */
+
+#if SPI_CS_IRQ == EXTI4_IRQn
+
+    void EXTI4_IRQHandler()
+    {
+        if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_4) != RESET)
+        {
             __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_4);
             Interrupt::InvokeHandler(EXTI4_IRQn);
         }
     }
 
-    void DMA1_Stream0_IRQHandler() {
+#elif SPI_CS_IRQ == EXTI15_10_IRQn
+
+    void EXTI15_10_IRQHandler()
+    {
+        /* PA15 is in the EXTI15_10 group — check and clear pin 15 only     */
+        if (__HAL_GPIO_EXTI_GET_IT(GPIO_PIN_15) != RESET)
+        {
+            __HAL_GPIO_EXTI_CLEAR_IT(GPIO_PIN_15);
+            Interrupt::InvokeHandler(EXTI15_10_IRQn);
+        }
+    }
+
+#else
+    #error "SPI_CS_IRQ not defined or not supported. Add a handler for your board."
+#endif
+
+    /* ── DMA handlers (comms SPI DMA — same on all boards) ─────────────────
+     * STM32H7_SPIComms uses DMA1 Stream0 (TX) and Stream1 (RX).            */
+
+    void DMA1_Stream0_IRQHandler()
+    {
         Interrupt::InvokeHandler(DMA1_Stream0_IRQn);
     }
 
-    void DMA1_Stream1_IRQHandler() {
+    void DMA1_Stream1_IRQHandler()
+    {
         Interrupt::InvokeHandler(DMA1_Stream1_IRQn);
     }
 
-    void TIM2_IRQHandler() {
-        if (TIM2->SR & TIM_SR_UIF) {
+    /* ── Timer handlers ──────────────────────────────────────────────────── */
+
+    void TIM2_IRQHandler()
+    {
+        if (TIM2->SR & TIM_SR_UIF)
+        {
             TIM2->SR &= ~TIM_SR_UIF;
             Interrupt::InvokeHandler(TIM2_IRQn);
         }
     }
 
-    void TIM3_IRQHandler() {
-        if (TIM3->SR & TIM_SR_UIF) {
+    void TIM3_IRQHandler()
+    {
+        if (TIM3->SR & TIM_SR_UIF)
+        {
             TIM3->SR &= ~TIM_SR_UIF;
             Interrupt::InvokeHandler(TIM3_IRQn);
         }
     }
 
-    void TIM4_IRQHandler() {
-        if (TIM4->SR & TIM_SR_UIF) {
+    void TIM4_IRQHandler()
+    {
+        if (TIM4->SR & TIM_SR_UIF)
+        {
             TIM4->SR &= ~TIM_SR_UIF;
             Interrupt::InvokeHandler(TIM4_IRQn);
         }

--- a/Src/main.cpp
+++ b/Src/main.cpp
@@ -1,20 +1,20 @@
 /*
   Remora is a free, opensource LinuxCNC component and Programmable Realtime
-	Unit (PRU) firmware to implement a LinuxCNC based CNC controller.
-	Copyright (C) 2025 Scott Alford (scotta)
+  Unit (PRU) firmware to implement a LinuxCNC based CNC controller.
+  Copyright (C) 2025 Scott Alford (scotta)
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "main.h"
@@ -29,21 +29,20 @@
 #include "remora-hal/STM32H7_SPIComms.h"
 #include "remora-hal/STM32H7_timer.h"
 #include "remora-hal/STM32H7_UART.h"
+#include "remora-hal/STM32H7_SDIO.h"
 
-
-void SystemClock_Config(void);
-void PeriphCommonClock_Config(void);
-static void MPU_Config(void);
-static void MX_USART1_UART_Init(void);
 #ifdef SD_SPI
   #include "remora-hal/STM32H7_SPI_SDcard.h"
-#else
-  #include "remora-hal/STM32H7_SDIO.h"
-  static void MX_GPIO_Init(void);
-  static void MX_SDMMC1_SD_Init(void);
 #endif
 
-// printf retargeting — uses g_uart set during STM32H7_UART construction
+/* hsd1 is declared in STM32H7_SDIO.cpp and referenced by bsp_driver_sd.c
+ * and stm32h7xx_it.c. Declared extern here to keep main.cpp clean.         */
+extern SD_HandleTypeDef hsd1;
+
+void SystemClock_Config(void);
+static void MPU_Config(void);
+
+/* printf retargeting via g_uart set during STM32H7_UART construction       */
 extern "C" {
     int __io_putchar(int ch)
     {
@@ -54,7 +53,6 @@ extern "C" {
 
 int main(void)
 {
-
 #ifdef HAS_BOOTLOADER
     HAL_RCC_DeInit();
     HAL_DeInit();
@@ -65,204 +63,247 @@ int main(void)
     __enable_irq();
 #endif
 
-	HAL_Init();
-  //MPU_Config();
-	SystemClock_Config();
-	PeriphCommonClock_Config();
+    MPU_Config();
+    HAL_Init();
+    SystemClock_Config();
 
-	// Enable  instruction cache
-	SCB_InvalidateICache();
-	SCB_EnableICache();
+    /* Enable instruction cache                                               */
+    SCB_InvalidateICache();
+    SCB_EnableICache();
 
-  __HAL_RCC_DMA1_CLK_ENABLE();
+    __HAL_RCC_DMA1_CLK_ENABLE();
 
-  auto uart = std::make_unique<STM32H7_UART>(REMORA_UART_TX, REMORA_UART_RX);
-  uart->init();
+    /* ── UART ────────────────────────────────────────────────────────────── */
+    auto uart = std::make_unique<STM32H7_UART>(REMORA_UART_TX, REMORA_UART_RX);
+    uart->init();
 
+    /* ── SD card ─────────────────────────────────────────────────────────── */
 #ifdef SD_SPI
-  auto sdCard = std::make_unique<STM32H7_SPI_SDcard>(SD_MOSI, SD_MISO, SD_CLK, SD_CS);
-  sdCard->init();
+    auto sdCard = std::make_unique<STM32H7_SPI_SDcard>(
+                      SD_MOSI, SD_MISO, SD_CLK, SD_CS);
+    sdCard->init();
 #else
-  auto sdCard = std::make_unique<STM32H7_SDIO>(REMORA_SD_CMD, REMORA_SD_CLK, REMORA_SD_D0, REMORA_SD_D1, REMORA_SD_D2, REMORA_SD_D3);
-  sdCard->init();
+    auto sdCard = std::make_unique<STM32H7_SDIO>(
+                      REMORA_SD_CMD, REMORA_SD_CLK,
+                      REMORA_SD_D0,  REMORA_SD_D1,
+                      REMORA_SD_D2,  REMORA_SD_D3);
+    sdCard->init();
 #endif
 
-  auto comms = std::make_unique<STM32H7_SPIComms>(&rxData, &txData, SPI_MOSI, SPI_MISO, SPI_CLK, SPI_CS);
-	auto commsHandler = std::make_shared<CommsHandler>();
-	commsHandler->setInterface(std::move(comms));
+    MX_FATFS_Init();
 
-  auto baseTimer = std::make_unique<STM32H7_timer>(TIM3, TIM3_IRQn, Config::pruBaseFreq, nullptr, Config::baseThreadIrqPriority);
-  auto servoTimer = std::make_unique<STM32H7_timer>(TIM2, TIM2_IRQn, Config::pruServoFreq, nullptr, Config::servoThreadIrqPriority);
-  auto serialTimer = std::make_unique<STM32H7_timer>(TIM4, TIM4_IRQn, Config::pruSerialFreq, nullptr, Config::serialThreadIrqPriority);
+    /* ── LinuxCNC comms SPI ───────────────────────────────────────────────── */
+    auto comms = std::make_unique<STM32H7_SPIComms>(
+                     &rxData, &txData,
+                     SPI_MOSI, SPI_MISO, SPI_CLK, SPI_CS);
+    auto commsHandler = std::make_shared<CommsHandler>();
+    commsHandler->setInterface(std::move(comms));
 
-  Remora* remora = new Remora(
+    /* ── Timers ───────────────────────────────────────────────────────────── */
+    auto baseTimer   = std::make_unique<STM32H7_timer>(
+                           TIM3, TIM3_IRQn,
+                           Config::pruBaseFreq, nullptr,
+                           Config::baseThreadIrqPriority);
+    auto servoTimer  = std::make_unique<STM32H7_timer>(
+                           TIM2, TIM2_IRQn,
+                           Config::pruServoFreq, nullptr,
+                           Config::servoThreadIrqPriority);
+    auto serialTimer = std::make_unique<STM32H7_timer>(
+                           TIM4, TIM4_IRQn,
+                           Config::pruSerialFreq, nullptr,
+                           Config::serialThreadIrqPriority);
+
+    /* ── Remora ───────────────────────────────────────────────────────────── */
+    Remora* remora = new Remora(
         commsHandler,
         std::move(baseTimer),
         std::move(servoTimer),
         std::move(serialTimer)
-  );
+    );
 
-	remora->run();
+    remora->run();
 }
 
-/**
-  * @brief System Clock Configuration
-  * @retval None
-  */
+/* ── System Clock Configuration ─────────────────────────────────────────── */
+/*
+ * Supports four configurations selected by preprocessor defines:
+ *
+ *   STM32H743xx + NUCLEO_H743  — 480 MHz, 8 MHz HSE (Nucleo STLink MCO)
+ *   STM32H743xx                — 480 MHz, 25 MHz HSE (SKR3, WeAct H743)
+ *   STM32H723xx + NUCLEO_H723  — 550 MHz, 8 MHz HSE (Nucleo STLink MCO)
+ *   STM32H723xx                — 550 MHz, 25 MHz HSE (Manta M8P V2.0)
+ *
+ * PLL2 provides the kernel clock for SPI1/2/3 and SDMMC peripherals.
+ * SDMMC is later reconfigured to PLL1 Q inside STM32H7_SDIO::mspInit().
+ */
 void SystemClock_Config(void)
 {
-  RCC_OscInitTypeDef RCC_OscInitStruct = {0};
-  RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
+    RCC_OscInitTypeDef       RCC_OscInitStruct   = {0};
+    RCC_ClkInitTypeDef       RCC_ClkInitStruct   = {0};
+    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
 
-  /** Supply configuration update enable
-  */
-  HAL_PWREx_ConfigSupply(PWR_LDO_SUPPLY);
- 
-  /** Configure the main internal regulator output voltage
-  */
-  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+    HAL_PWREx_ConfigSupply(PWR_LDO_SUPPLY);
+    __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+    while (!__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY)) {}
+    __HAL_RCC_SYSCFG_CLK_ENABLE();
+    __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE0);
+    while (!__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY)) {}
+    __HAL_RCC_PLL_PLLSOURCE_CONFIG(RCC_PLLSOURCE_HSE);
 
-  while(!__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY)) {}
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+    RCC_OscInitStruct.HSEState       = RCC_HSE_ON;
+    RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;
+    RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSE;
+    RCC_OscInitStruct.PLL.PLLRGE    = RCC_PLL1VCIRANGE_2;
+    RCC_OscInitStruct.PLL.PLLVCOSEL = RCC_PLL1VCOWIDE;
+    RCC_OscInitStruct.PLL.PLLFRACN  = 0;
 
-  __HAL_RCC_SYSCFG_CLK_ENABLE();
-  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE0);
+#if defined(STM32H743xx)
 
-  while(!__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY)) {}
+  #if defined(NUCLEO_H743)
+    /* Nucleo H743 — 8 MHz HSE (STLink MCO) → 480 MHz SYSCLK               */
+    RCC_OscInitStruct.PLL.PLLM = 2;
+    RCC_OscInitStruct.PLL.PLLN = 240;
+    RCC_OscInitStruct.PLL.PLLP = 2;
+    RCC_OscInitStruct.PLL.PLLQ = 20;
+    RCC_OscInitStruct.PLL.PLLR = 2;
 
-  /** Macro to configure the PLL clock source
-  */
-  __HAL_RCC_PLL_PLLSOURCE_CONFIG(RCC_PLLSOURCE_HSE);
+    PeriphClkInitStruct.PLL2.PLL2M      = 2;
+    PeriphClkInitStruct.PLL2.PLL2N      = 240;
+    PeriphClkInitStruct.PLL2.PLL2P      = 2;
+    PeriphClkInitStruct.PLL2.PLL2Q      = 20;
+    PeriphClkInitStruct.PLL2.PLL2R      = 80;
+    PeriphClkInitStruct.PLL2.PLL2RGE    = RCC_PLL2VCIRANGE_2;
+    PeriphClkInitStruct.PLL2.PLL2VCOSEL = RCC_PLL2VCOWIDE;
+    PeriphClkInitStruct.PLL2.PLL2FRACN  = 0;
+    #define FLASH_LATENCY FLASH_LATENCY_4
 
-  /** Initializes the RCC Oscillators according to the specified parameters
-  * in the RCC_OscInitTypeDef structure.
-  */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
-  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
-  RCC_OscInitStruct.PLL.PLLM = 5;
-  RCC_OscInitStruct.PLL.PLLN = 192;
-  RCC_OscInitStruct.PLL.PLLP = 2;
-  RCC_OscInitStruct.PLL.PLLQ = 4;
-  RCC_OscInitStruct.PLL.PLLR = 2;
-  RCC_OscInitStruct.PLL.PLLRGE = RCC_PLL1VCIRANGE_2;
-  RCC_OscInitStruct.PLL.PLLVCOSEL = RCC_PLL1VCOWIDE;
-  RCC_OscInitStruct.PLL.PLLFRACN = 0;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
+  #else
+    /* SKR3 / WeAct H743 — 25 MHz HSE → 480 MHz SYSCLK                      */
+    /* PLL1: 25/5 = 5 MHz × 192 / 2 = 480 MHz                               */
+    RCC_OscInitStruct.PLL.PLLM = 5;
+    RCC_OscInitStruct.PLL.PLLN = 192;
+    RCC_OscInitStruct.PLL.PLLP = 2;
+    RCC_OscInitStruct.PLL.PLLQ = 4;
+    RCC_OscInitStruct.PLL.PLLR = 2;
 
-  /** Initializes the CPU, AHB and APB buses clocks
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK|RCC_CLOCKTYPE_SYSCLK
-                              |RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2
-                              |RCC_CLOCKTYPE_D3PCLK1|RCC_CLOCKTYPE_D1PCLK1;
-  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
-  RCC_ClkInitStruct.SYSCLKDivider = RCC_SYSCLK_DIV1;
-  RCC_ClkInitStruct.AHBCLKDivider = RCC_HCLK_DIV2;
-  RCC_ClkInitStruct.APB3CLKDivider = RCC_APB3_DIV2;
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_APB1_DIV2;
-  RCC_ClkInitStruct.APB2CLKDivider = RCC_APB2_DIV2;
-  RCC_ClkInitStruct.APB4CLKDivider = RCC_APB4_DIV2;
+    /* PLL2: 25/2 = 12.5 MHz × 12 = 150 MHz VCO → /2 = 75 MHz SPI/SDMMC   */
+    PeriphClkInitStruct.PLL2.PLL2M      = 2;
+    PeriphClkInitStruct.PLL2.PLL2N      = 12;
+    PeriphClkInitStruct.PLL2.PLL2P      = 1;
+    PeriphClkInitStruct.PLL2.PLL2Q      = 10;
+    PeriphClkInitStruct.PLL2.PLL2R      = 2;
+    PeriphClkInitStruct.PLL2.PLL2RGE    = RCC_PLL2VCIRANGE_3;
+    PeriphClkInitStruct.PLL2.PLL2VCOSEL = RCC_PLL2VCOMEDIUM;
+    PeriphClkInitStruct.PLL2.PLL2FRACN  = 0;
+    #define FLASH_LATENCY FLASH_LATENCY_4
+  #endif
 
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4) != HAL_OK)
-  {
-    Error_Handler();
-  }
+#elif defined(STM32H723xx)
+
+  #if defined(NUCLEO_H723)
+    /* Nucleo H723 — 8 MHz HSE (STLink MCO) → 550 MHz SYSCLK               */
+    RCC_OscInitStruct.PLL.PLLM = 2;
+    RCC_OscInitStruct.PLL.PLLN = 120;
+    RCC_OscInitStruct.PLL.PLLP = 1;
+    RCC_OscInitStruct.PLL.PLLQ = 10;
+    RCC_OscInitStruct.PLL.PLLR = 1;
+
+    PeriphClkInitStruct.PLL2.PLL2M      = 2;
+    PeriphClkInitStruct.PLL2.PLL2N      = 120;
+    PeriphClkInitStruct.PLL2.PLL2P      = 1;
+    PeriphClkInitStruct.PLL2.PLL2Q      = 10;
+    PeriphClkInitStruct.PLL2.PLL2R      = 40;
+    PeriphClkInitStruct.PLL2.PLL2RGE    = RCC_PLL2VCIRANGE_2;
+    PeriphClkInitStruct.PLL2.PLL2VCOSEL = RCC_PLL2VCOWIDE;
+    PeriphClkInitStruct.PLL2.PLL2FRACN  = 0;
+    #define FLASH_LATENCY FLASH_LATENCY_3
+
+  #else
+    /* Manta M8P V2.0 — 25 MHz HSE → 550 MHz SYSCLK                         */
+    /* PLL1: 25/5 = 5 MHz × 110 / 1 = 550 MHz                               */
+    RCC_OscInitStruct.PLL.PLLM = 5;
+    RCC_OscInitStruct.PLL.PLLN = 110;
+    RCC_OscInitStruct.PLL.PLLP = 1;
+    RCC_OscInitStruct.PLL.PLLQ = 10;
+    RCC_OscInitStruct.PLL.PLLR = 10;
+
+    /* PLL2: 25/2 = 12.5 MHz × 16 = 200 MHz VCO → /2 = 100 MHz SPI/SDMMC  */
+    PeriphClkInitStruct.PLL2.PLL2M      = 2;
+    PeriphClkInitStruct.PLL2.PLL2N      = 16;
+    PeriphClkInitStruct.PLL2.PLL2P      = 1;
+    PeriphClkInitStruct.PLL2.PLL2Q      = 10;
+    PeriphClkInitStruct.PLL2.PLL2R      = 2;
+    PeriphClkInitStruct.PLL2.PLL2RGE    = RCC_PLL2VCIRANGE_3;
+    PeriphClkInitStruct.PLL2.PLL2VCOSEL = RCC_PLL2VCOWIDE;
+    PeriphClkInitStruct.PLL2.PLL2FRACN  = 0;
+    #define FLASH_LATENCY FLASH_LATENCY_3
+  #endif
+
+#endif /* STM32H723xx */
+
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
+        Error_Handler();
+
+    RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK    | RCC_CLOCKTYPE_SYSCLK |
+                                  RCC_CLOCKTYPE_PCLK1   | RCC_CLOCKTYPE_PCLK2  |
+                                  RCC_CLOCKTYPE_D3PCLK1 | RCC_CLOCKTYPE_D1PCLK1;
+    RCC_ClkInitStruct.SYSCLKSource   = RCC_SYSCLKSOURCE_PLLCLK;
+    RCC_ClkInitStruct.SYSCLKDivider  = RCC_SYSCLK_DIV1;
+    RCC_ClkInitStruct.AHBCLKDivider  = RCC_HCLK_DIV2;
+    RCC_ClkInitStruct.APB3CLKDivider = RCC_APB3_DIV2;
+    RCC_ClkInitStruct.APB1CLKDivider = RCC_APB1_DIV2;
+    RCC_ClkInitStruct.APB2CLKDivider = RCC_APB2_DIV2;
+    RCC_ClkInitStruct.APB4CLKDivider = RCC_APB4_DIV2;
+
+    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY) != HAL_OK)
+        Error_Handler();
+
+    /* Peripheral kernel clocks from PLL2
+     * SDMMC is set here to PLL2 then overridden to PLL1 Q inside
+     * STM32H7_SDIO::mspInit() when HAL_SD_Init() fires.                    */
+    PeriphClkInitStruct.PeriphClockSelection  = RCC_PERIPHCLK_SDMMC |
+                                                RCC_PERIPHCLK_SPI123;
+    PeriphClkInitStruct.SdmmcClockSelection   = RCC_SDMMCCLKSOURCE_PLL2;
+    PeriphClkInitStruct.Spi123ClockSelection  = RCC_SPI123CLKSOURCE_PLL2;
+
+    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
+        Error_Handler();
 }
 
-/**
-  * @brief Peripherals Common Clock Configuration
-  * @retval None
-  */
-void PeriphCommonClock_Config(void)
-{
-  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
-
-  /** Initializes the peripherals clock
-  */
-  PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_SDMMC|RCC_PERIPHCLK_SPI1;
-  PeriphClkInitStruct.PLL2.PLL2M = 2;
-  PeriphClkInitStruct.PLL2.PLL2N = 12;
-  PeriphClkInitStruct.PLL2.PLL2P = 1;
-  PeriphClkInitStruct.PLL2.PLL2Q = 10;
-  PeriphClkInitStruct.PLL2.PLL2R = 2;
-  PeriphClkInitStruct.PLL2.PLL2RGE = RCC_PLL2VCIRANGE_3;
-  PeriphClkInitStruct.PLL2.PLL2VCOSEL = RCC_PLL2VCOMEDIUM;
-  PeriphClkInitStruct.PLL2.PLL2FRACN = 0;
-  PeriphClkInitStruct.SdmmcClockSelection = RCC_SDMMCCLKSOURCE_PLL2;
-  PeriphClkInitStruct.Spi123ClockSelection = RCC_SPI123CLKSOURCE_PLL2;
-  if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
-  {
-    Error_Handler();
-  }
-}
-
-/* USER CODE BEGIN 4 */
-
-/* USER CODE END 4 */
-
+/* ── MPU Configuration ───────────────────────────────────────────────────── */
 void MPU_Config(void)
 {
-  MPU_Region_InitTypeDef MPU_InitStruct = {0};
+    MPU_Region_InitTypeDef MPU_InitStruct = {0};
 
-  /* Disables the MPU */
-  HAL_MPU_Disable();
+    HAL_MPU_Disable();
 
-  /** Initializes and configures the Region and the memory to be protected
-  */
-  MPU_InitStruct.Enable = MPU_REGION_ENABLE;
-  MPU_InitStruct.Number = MPU_REGION_NUMBER0;
-  MPU_InitStruct.BaseAddress = 0x0;
-  MPU_InitStruct.Size = MPU_REGION_SIZE_4GB;
-  MPU_InitStruct.SubRegionDisable = 0x87;
-  MPU_InitStruct.TypeExtField = MPU_TEX_LEVEL0;
-  MPU_InitStruct.AccessPermission = MPU_REGION_NO_ACCESS;
-  MPU_InitStruct.DisableExec = MPU_INSTRUCTION_ACCESS_DISABLE;
-  MPU_InitStruct.IsShareable = MPU_ACCESS_SHAREABLE;
-  MPU_InitStruct.IsCacheable = MPU_ACCESS_NOT_CACHEABLE;
-  MPU_InitStruct.IsBufferable = MPU_ACCESS_NOT_BUFFERABLE;
+    MPU_InitStruct.Enable            = MPU_REGION_ENABLE;
+    MPU_InitStruct.Number            = MPU_REGION_NUMBER0;
+    MPU_InitStruct.BaseAddress       = 0x0;
+    MPU_InitStruct.Size              = MPU_REGION_SIZE_4GB;
+    MPU_InitStruct.SubRegionDisable  = 0x87;
+    MPU_InitStruct.TypeExtField      = MPU_TEX_LEVEL0;
+    MPU_InitStruct.AccessPermission  = MPU_REGION_NO_ACCESS;
+    MPU_InitStruct.DisableExec       = MPU_INSTRUCTION_ACCESS_DISABLE;
+    MPU_InitStruct.IsShareable       = MPU_ACCESS_SHAREABLE;
+    MPU_InitStruct.IsCacheable       = MPU_ACCESS_NOT_CACHEABLE;
+    MPU_InitStruct.IsBufferable      = MPU_ACCESS_NOT_BUFFERABLE;
 
-  HAL_MPU_ConfigRegion(&MPU_InitStruct);
-
-  /* Enables the MPU */
-  HAL_MPU_Enable(MPU_PRIVILEGED_DEFAULT);
-
+    HAL_MPU_ConfigRegion(&MPU_InitStruct);
+    HAL_MPU_Enable(MPU_PRIVILEGED_DEFAULT);
 }
 
-
-/**
-  * @brief  This function is executed in case of error occurrence.
-  * @retval None
-  */
+/* ── Error handler ───────────────────────────────────────────────────────── */
 void Error_Handler(void)
 {
-  /* USER CODE BEGIN Error_Handler_Debug */
-  /* User can add his own implementation to report the HAL error return state */
-
-	printf("error\n\r");
-
-  __disable_irq();
-  while (1)
-  {
-  }
-  /* USER CODE END Error_Handler_Debug */
+    printf("error\n\r");
+    __disable_irq();
+    while (1) {}
 }
 
-#ifdef  USE_FULL_ASSERT
-/**
-  * @brief  Reports the name of the source file and the source line number
-  *         where the assert_param error has occurred.
-  * @param  file: pointer to the source file name
-  * @param  line: assert_param error line source number
-  * @retval None
-  */
+#ifdef USE_FULL_ASSERT
 void assert_failed(uint8_t *file, uint32_t line)
 {
-  /* USER CODE BEGIN 6 */
-  /* User can add his own implementation to report the file name and line number,
-     ex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
-  /* USER CODE END 6 */
 }
-#endif /* USE_FULL_ASSERT */
+#endif

--- a/StartupH723/startup_stm32h723vgtx.s
+++ b/StartupH723/startup_stm32h723vgtx.s
@@ -1,0 +1,756 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32h723xx.s
+  * @author    MCD Application Team
+  * @brief     STM32H723xx Devices vector table for GCC based toolchain.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+  .cpu cortex-m7
+  .fpu softvfp
+  .thumb
+
+.global  g_pfnVectors
+.global  Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word  _sidata
+/* start address for the .data section. defined in linker script */
+.word  _sdata
+/* end address for the .data section. defined in linker script */
+.word  _edata
+/* start address for the .bss section. defined in linker script */
+.word  _sbss
+/* end address for the .bss section. defined in linker script */
+.word  _ebss
+/* stack used for SystemInit_ExtMemCtl; always internal RAM used */
+
+/**
+ * @brief  This is the code that gets called when the processor first
+ *          starts execution following a reset event. Only the absolutely
+ *          necessary set is performed, after which the application
+ *          supplied main() routine is called.
+ * @param  None
+ * @retval : None
+*/
+
+    .section  .text.Reset_Handler
+  .weak  Reset_Handler
+  .type  Reset_Handler, %function
+Reset_Handler:
+  ldr   sp, =_estack      /* set stack pointer */
+
+/* Call the clock system initialization function.*/
+  bl  SystemInit
+
+/* Copy the data segment initializers from flash to SRAM */
+  ldr r0, =_sdata
+  ldr r1, =_edata
+  ldr r2, =_sidata
+  movs r3, #0
+  b LoopCopyDataInit
+
+CopyDataInit:
+  ldr r4, [r2, r3]
+  str r4, [r0, r3]
+  adds r3, r3, #4
+
+LoopCopyDataInit:
+  adds r4, r0, r3
+  cmp r4, r1
+  bcc CopyDataInit
+/* Zero fill the bss segment. */
+  ldr r2, =_sbss
+  ldr r4, =_ebss
+  movs r3, #0
+  b LoopFillZerobss
+
+FillZerobss:
+  str  r3, [r2]
+  adds r2, r2, #4
+
+LoopFillZerobss:
+  cmp r2, r4
+  bcc FillZerobss
+
+/* Call static constructors */
+    bl __libc_init_array
+/* Call the application's entry point.*/
+  bl  main
+  bx  lr
+.size  Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ * @param  None
+ * @retval None
+*/
+    .section  .text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+  b  Infinite_Loop
+  .size  Default_Handler, .-Default_Handler
+/******************************************************************************
+*
+* The minimal vector table for a Cortex M. Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+*
+*******************************************************************************/
+   .section  .isr_vector,"a",%progbits
+  .type  g_pfnVectors, %object
+  .size  g_pfnVectors, .-g_pfnVectors
+
+
+g_pfnVectors:
+  .word  _estack
+  .word  Reset_Handler
+
+  .word  NMI_Handler
+  .word  HardFault_Handler
+  .word  MemManage_Handler
+  .word  BusFault_Handler
+  .word  UsageFault_Handler
+  .word  0
+  .word  0
+  .word  0
+  .word  0
+  .word  SVC_Handler
+  .word  DebugMon_Handler
+  .word  0
+  .word  PendSV_Handler
+  .word  SysTick_Handler
+
+  /* External Interrupts */
+  .word     WWDG_IRQHandler                   /* Window WatchDog              */
+  .word     PVD_AVD_IRQHandler                /* PVD/AVD through EXTI Line detection */
+  .word     TAMP_STAMP_IRQHandler             /* Tamper and TimeStamps through the EXTI line */
+  .word     RTC_WKUP_IRQHandler               /* RTC Wakeup through the EXTI line */
+  .word     FLASH_IRQHandler                  /* FLASH                        */
+  .word     RCC_IRQHandler                    /* RCC                          */
+  .word     EXTI0_IRQHandler                  /* EXTI Line0                   */
+  .word     EXTI1_IRQHandler                  /* EXTI Line1                   */
+  .word     EXTI2_IRQHandler                  /* EXTI Line2                   */
+  .word     EXTI3_IRQHandler                  /* EXTI Line3                   */
+  .word     EXTI4_IRQHandler                  /* EXTI Line4                   */
+  .word     DMA1_Stream0_IRQHandler           /* DMA1 Stream 0                */
+  .word     DMA1_Stream1_IRQHandler           /* DMA1 Stream 1                */
+  .word     DMA1_Stream2_IRQHandler           /* DMA1 Stream 2                */
+  .word     DMA1_Stream3_IRQHandler           /* DMA1 Stream 3                */
+  .word     DMA1_Stream4_IRQHandler           /* DMA1 Stream 4                */
+  .word     DMA1_Stream5_IRQHandler           /* DMA1 Stream 5                */
+  .word     DMA1_Stream6_IRQHandler           /* DMA1 Stream 6                */
+  .word     ADC_IRQHandler                    /* ADC1, ADC2 and ADC3s         */
+  .word     FDCAN1_IT0_IRQHandler             /* FDCAN1 interrupt line 0      */
+  .word     FDCAN2_IT0_IRQHandler             /* FDCAN2 interrupt line 0      */
+  .word     FDCAN1_IT1_IRQHandler             /* FDCAN1 interrupt line 1      */
+  .word     FDCAN2_IT1_IRQHandler             /* FDCAN2 interrupt line 1      */
+  .word     EXTI9_5_IRQHandler                /* External Line[9:5]s          */
+  .word     TIM1_BRK_IRQHandler               /* TIM1 Break interrupt         */
+  .word     TIM1_UP_IRQHandler                /* TIM1 Update interrupt        */
+  .word     TIM1_TRG_COM_IRQHandler           /* TIM1 Trigger and Commutation interrupt */
+  .word     TIM1_CC_IRQHandler                /* TIM1 Capture Compare         */
+  .word     TIM2_IRQHandler                   /* TIM2                         */
+  .word     TIM3_IRQHandler                   /* TIM3                         */
+  .word     TIM4_IRQHandler                   /* TIM4                         */
+  .word     I2C1_EV_IRQHandler                /* I2C1 Event                   */
+  .word     I2C1_ER_IRQHandler                /* I2C1 Error                   */
+  .word     I2C2_EV_IRQHandler                /* I2C2 Event                   */
+  .word     I2C2_ER_IRQHandler                /* I2C2 Error                   */
+  .word     SPI1_IRQHandler                   /* SPI1                         */
+  .word     SPI2_IRQHandler                   /* SPI2                         */
+  .word     USART1_IRQHandler                 /* USART1                       */
+  .word     USART2_IRQHandler                 /* USART2                       */
+  .word     USART3_IRQHandler                 /* USART3                       */
+  .word     EXTI15_10_IRQHandler              /* External Line[15:10]s        */
+  .word     RTC_Alarm_IRQHandler              /* RTC Alarm (A and B) through EXTI Line */
+  .word     0                                 /* Reserved                     */
+  .word     TIM8_BRK_TIM12_IRQHandler         /* TIM8 Break and TIM12         */
+  .word     TIM8_UP_TIM13_IRQHandler          /* TIM8 Update and TIM13        */
+  .word     TIM8_TRG_COM_TIM14_IRQHandler     /* TIM8 Trigger and Commutation and TIM14 */
+  .word     TIM8_CC_IRQHandler                /* TIM8 Capture Compare         */
+  .word     DMA1_Stream7_IRQHandler           /* DMA1 Stream7                 */
+  .word     FMC_IRQHandler                    /* FMC                          */
+  .word     SDMMC1_IRQHandler                 /* SDMMC1                       */
+  .word     TIM5_IRQHandler                   /* TIM5                         */
+  .word     SPI3_IRQHandler                   /* SPI3                         */
+  .word     UART4_IRQHandler                  /* UART4                        */
+  .word     UART5_IRQHandler                  /* UART5                        */
+  .word     TIM6_DAC_IRQHandler               /* TIM6 and DAC1&2 underrun errors */
+  .word     TIM7_IRQHandler                   /* TIM7                         */
+  .word     DMA2_Stream0_IRQHandler           /* DMA2 Stream 0                */
+  .word     DMA2_Stream1_IRQHandler           /* DMA2 Stream 1                */
+  .word     DMA2_Stream2_IRQHandler           /* DMA2 Stream 2                */
+  .word     DMA2_Stream3_IRQHandler           /* DMA2 Stream 3                */
+  .word     DMA2_Stream4_IRQHandler           /* DMA2 Stream 4                */
+  .word     ETH_IRQHandler                    /* Ethernet                     */
+  .word     ETH_WKUP_IRQHandler               /* Ethernet Wakeup through EXTI line */
+  .word     FDCAN_CAL_IRQHandler              /* FDCAN calibration unit interrupt*/
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     DMA2_Stream5_IRQHandler           /* DMA2 Stream 5                */
+  .word     DMA2_Stream6_IRQHandler           /* DMA2 Stream 6                */
+  .word     DMA2_Stream7_IRQHandler           /* DMA2 Stream 7                */
+  .word     USART6_IRQHandler                 /* USART6                       */
+  .word     I2C3_EV_IRQHandler                /* I2C3 event                   */
+  .word     I2C3_ER_IRQHandler                /* I2C3 error                   */
+  .word     OTG_HS_EP1_OUT_IRQHandler         /* USB OTG HS End Point 1 Out   */
+  .word     OTG_HS_EP1_IN_IRQHandler          /* USB OTG HS End Point 1 In    */
+  .word     OTG_HS_WKUP_IRQHandler            /* USB OTG HS Wakeup through EXTI */
+  .word     OTG_HS_IRQHandler                 /* USB OTG HS                   */
+  .word     DCMI_PSSI_IRQHandler              /* DCMI, PSSI                   */
+  .word     0                                 /* Reserved                     */
+  .word     RNG_IRQHandler                    /* Rng                          */
+  .word     FPU_IRQHandler                    /* FPU                          */
+  .word     UART7_IRQHandler                  /* UART7                        */
+  .word     UART8_IRQHandler                  /* UART8                        */
+  .word     SPI4_IRQHandler                   /* SPI4                         */
+  .word     SPI5_IRQHandler                   /* SPI5                         */
+  .word     SPI6_IRQHandler                   /* SPI6                         */
+  .word     SAI1_IRQHandler                   /* SAI1                         */
+  .word     LTDC_IRQHandler                   /* LTDC                         */
+  .word     LTDC_ER_IRQHandler                /* LTDC error                   */
+  .word     DMA2D_IRQHandler                  /* DMA2D                        */
+  .word     0                                 /* Reserved                     */
+  .word     OCTOSPI1_IRQHandler               /* OCTOSPI1                     */
+  .word     LPTIM1_IRQHandler                 /* LPTIM1                       */
+  .word     CEC_IRQHandler                    /* HDMI_CEC                     */
+  .word     I2C4_EV_IRQHandler                /* I2C4 Event                   */
+  .word     I2C4_ER_IRQHandler                /* I2C4 Error                   */
+  .word     SPDIF_RX_IRQHandler               /* SPDIF_RX                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     DMAMUX1_OVR_IRQHandler            /* DMAMUX1 Overrun interrupt    */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     0                                 /* Reserved                     */
+  .word     DFSDM1_FLT0_IRQHandler            /* DFSDM Filter0 Interrupt      */
+  .word     DFSDM1_FLT1_IRQHandler            /* DFSDM Filter1 Interrupt      */
+  .word     DFSDM1_FLT2_IRQHandler            /* DFSDM Filter2 Interrupt      */
+  .word     DFSDM1_FLT3_IRQHandler            /* DFSDM Filter3 Interrupt      */
+  .word     0                                 /* Reserved                     */
+  .word     SWPMI1_IRQHandler                 /* Serial Wire Interface 1 global interrupt */
+  .word     TIM15_IRQHandler                  /* TIM15 global Interrupt          */
+  .word     TIM16_IRQHandler                  /* TIM16 global Interrupt          */
+  .word     TIM17_IRQHandler                  /* TIM17 global Interrupt          */
+  .word     MDIOS_WKUP_IRQHandler             /* MDIOS Wakeup  Interrupt         */
+  .word     MDIOS_IRQHandler                  /* MDIOS global Interrupt          */
+  .word     0                                 /* Reserved                        */
+  .word     MDMA_IRQHandler                   /* MDMA global Interrupt           */
+  .word     0                                 /* Reserved                        */
+  .word     SDMMC2_IRQHandler                 /* SDMMC2 global Interrupt         */
+  .word     HSEM1_IRQHandler                  /* HSEM1 global Interrupt          */
+  .word     0                                 /* Reserved                        */
+  .word     ADC3_IRQHandler                   /* ADC3 global Interrupt           */
+  .word     DMAMUX2_OVR_IRQHandler            /* DMAMUX Overrun interrupt        */
+  .word     BDMA_Channel0_IRQHandler          /* BDMA Channel 0 global Interrupt */
+  .word     BDMA_Channel1_IRQHandler          /* BDMA Channel 1 global Interrupt */
+  .word     BDMA_Channel2_IRQHandler          /* BDMA Channel 2 global Interrupt */
+  .word     BDMA_Channel3_IRQHandler          /* BDMA Channel 3 global Interrupt */
+  .word     BDMA_Channel4_IRQHandler          /* BDMA Channel 4 global Interrupt */
+  .word     BDMA_Channel5_IRQHandler          /* BDMA Channel 5 global Interrupt */
+  .word     BDMA_Channel6_IRQHandler          /* BDMA Channel 6 global Interrupt */
+  .word     BDMA_Channel7_IRQHandler          /* BDMA Channel 7 global Interrupt */
+  .word     COMP1_IRQHandler                  /* COMP1 global Interrupt          */
+  .word     LPTIM2_IRQHandler                 /* LP TIM2 global interrupt        */
+  .word     LPTIM3_IRQHandler                 /* LP TIM3 global interrupt        */
+  .word     LPTIM4_IRQHandler                 /* LP TIM4 global interrupt        */
+  .word     LPTIM5_IRQHandler                 /* LP TIM5 global interrupt        */
+  .word     LPUART1_IRQHandler                /* LP UART1 interrupt              */
+  .word     0                                 /* Reserved                        */
+  .word     CRS_IRQHandler                    /* Clock Recovery Global Interrupt */
+  .word     ECC_IRQHandler                    /* ECC diagnostic Global Interrupt */
+  .word     SAI4_IRQHandler                   /* SAI4 global interrupt           */
+  .word     DTS_IRQHandler                    /* Digital Temperature Sensor  interrupt */
+  .word     0                                 /* Reserved                              */
+  .word     WAKEUP_PIN_IRQHandler             /* Interrupt for all 6 wake-up pins      */
+  .word     OCTOSPI2_IRQHandler               /* OCTOSPI2 Interrupt       */
+  .word     0                                 /* Reserved                 */
+  .word     0                                 /* Reserved                 */
+  .word     FMAC_IRQHandler                   /* FMAC Interrupt           */
+  .word     CORDIC_IRQHandler                 /* CORDIC Interrupt         */
+  .word     UART9_IRQHandler                  /* UART9 Interrupt          */
+  .word     USART10_IRQHandler                /* UART10 Interrupt         */
+  .word     I2C5_EV_IRQHandler                /* I2C5 Event Interrupt     */
+  .word     I2C5_ER_IRQHandler                /* I2C5 Error Interrupt     */
+  .word     FDCAN3_IT0_IRQHandler             /* FDCAN3 interrupt line 0  */
+  .word     FDCAN3_IT1_IRQHandler             /* FDCAN3 interrupt line 1  */
+  .word     TIM23_IRQHandler                  /* TIM23 global interrupt   */
+  .word     TIM24_IRQHandler                  /* TIM24 global interrupt   */
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler.
+* As they are weak aliases, any function with the same name will override
+* this definition.
+*
+*******************************************************************************/
+   .weak      NMI_Handler
+   .thumb_set NMI_Handler,Default_Handler
+
+   .weak      HardFault_Handler
+   .thumb_set HardFault_Handler,Default_Handler
+
+   .weak      MemManage_Handler
+   .thumb_set MemManage_Handler,Default_Handler
+
+   .weak      BusFault_Handler
+   .thumb_set BusFault_Handler,Default_Handler
+
+   .weak      UsageFault_Handler
+   .thumb_set UsageFault_Handler,Default_Handler
+
+   .weak      SVC_Handler
+   .thumb_set SVC_Handler,Default_Handler
+
+   .weak      DebugMon_Handler
+   .thumb_set DebugMon_Handler,Default_Handler
+
+   .weak      PendSV_Handler
+   .thumb_set PendSV_Handler,Default_Handler
+
+   .weak      SysTick_Handler
+   .thumb_set SysTick_Handler,Default_Handler
+
+   .weak      WWDG_IRQHandler
+   .thumb_set WWDG_IRQHandler,Default_Handler
+
+   .weak      PVD_AVD_IRQHandler
+   .thumb_set PVD_AVD_IRQHandler,Default_Handler
+
+   .weak      TAMP_STAMP_IRQHandler
+   .thumb_set TAMP_STAMP_IRQHandler,Default_Handler
+
+   .weak      RTC_WKUP_IRQHandler
+   .thumb_set RTC_WKUP_IRQHandler,Default_Handler
+
+   .weak      FLASH_IRQHandler
+   .thumb_set FLASH_IRQHandler,Default_Handler
+
+   .weak      RCC_IRQHandler
+   .thumb_set RCC_IRQHandler,Default_Handler
+
+   .weak      EXTI0_IRQHandler
+   .thumb_set EXTI0_IRQHandler,Default_Handler
+
+   .weak      EXTI1_IRQHandler
+   .thumb_set EXTI1_IRQHandler,Default_Handler
+
+   .weak      EXTI2_IRQHandler
+   .thumb_set EXTI2_IRQHandler,Default_Handler
+
+   .weak      EXTI3_IRQHandler
+   .thumb_set EXTI3_IRQHandler,Default_Handler
+
+   .weak      EXTI4_IRQHandler
+   .thumb_set EXTI4_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream0_IRQHandler
+   .thumb_set DMA1_Stream0_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream1_IRQHandler
+   .thumb_set DMA1_Stream1_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream2_IRQHandler
+   .thumb_set DMA1_Stream2_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream3_IRQHandler
+   .thumb_set DMA1_Stream3_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream4_IRQHandler
+   .thumb_set DMA1_Stream4_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream5_IRQHandler
+   .thumb_set DMA1_Stream5_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream6_IRQHandler
+   .thumb_set DMA1_Stream6_IRQHandler,Default_Handler
+
+   .weak      ADC_IRQHandler
+   .thumb_set ADC_IRQHandler,Default_Handler
+
+   .weak      FDCAN1_IT0_IRQHandler
+   .thumb_set FDCAN1_IT0_IRQHandler,Default_Handler
+
+   .weak      FDCAN2_IT0_IRQHandler
+   .thumb_set FDCAN2_IT0_IRQHandler,Default_Handler
+
+   .weak      FDCAN1_IT1_IRQHandler
+   .thumb_set FDCAN1_IT1_IRQHandler,Default_Handler
+
+   .weak      FDCAN2_IT1_IRQHandler
+   .thumb_set FDCAN2_IT1_IRQHandler,Default_Handler
+
+   .weak      EXTI9_5_IRQHandler
+   .thumb_set EXTI9_5_IRQHandler,Default_Handler
+
+   .weak      TIM1_BRK_IRQHandler
+   .thumb_set TIM1_BRK_IRQHandler,Default_Handler
+
+   .weak      TIM1_UP_IRQHandler
+   .thumb_set TIM1_UP_IRQHandler,Default_Handler
+
+   .weak      TIM1_TRG_COM_IRQHandler
+   .thumb_set TIM1_TRG_COM_IRQHandler,Default_Handler
+
+   .weak      TIM1_CC_IRQHandler
+   .thumb_set TIM1_CC_IRQHandler,Default_Handler
+
+   .weak      TIM2_IRQHandler
+   .thumb_set TIM2_IRQHandler,Default_Handler
+
+   .weak      TIM3_IRQHandler
+   .thumb_set TIM3_IRQHandler,Default_Handler
+
+   .weak      TIM4_IRQHandler
+   .thumb_set TIM4_IRQHandler,Default_Handler
+
+   .weak      I2C1_EV_IRQHandler
+   .thumb_set I2C1_EV_IRQHandler,Default_Handler
+
+   .weak      I2C1_ER_IRQHandler
+   .thumb_set I2C1_ER_IRQHandler,Default_Handler
+
+   .weak      I2C2_EV_IRQHandler
+   .thumb_set I2C2_EV_IRQHandler,Default_Handler
+
+   .weak      I2C2_ER_IRQHandler
+   .thumb_set I2C2_ER_IRQHandler,Default_Handler
+
+   .weak      SPI1_IRQHandler
+   .thumb_set SPI1_IRQHandler,Default_Handler
+
+   .weak      SPI2_IRQHandler
+   .thumb_set SPI2_IRQHandler,Default_Handler
+
+   .weak      USART1_IRQHandler
+   .thumb_set USART1_IRQHandler,Default_Handler
+
+   .weak      USART2_IRQHandler
+   .thumb_set USART2_IRQHandler,Default_Handler
+
+   .weak      USART3_IRQHandler
+   .thumb_set USART3_IRQHandler,Default_Handler
+
+   .weak      EXTI15_10_IRQHandler
+   .thumb_set EXTI15_10_IRQHandler,Default_Handler
+
+   .weak      RTC_Alarm_IRQHandler
+   .thumb_set RTC_Alarm_IRQHandler,Default_Handler
+
+   .weak      TIM8_BRK_TIM12_IRQHandler
+   .thumb_set TIM8_BRK_TIM12_IRQHandler,Default_Handler
+
+   .weak      TIM8_UP_TIM13_IRQHandler
+   .thumb_set TIM8_UP_TIM13_IRQHandler,Default_Handler
+
+   .weak      TIM8_TRG_COM_TIM14_IRQHandler
+   .thumb_set TIM8_TRG_COM_TIM14_IRQHandler,Default_Handler
+
+   .weak      TIM8_CC_IRQHandler
+   .thumb_set TIM8_CC_IRQHandler,Default_Handler
+
+   .weak      DMA1_Stream7_IRQHandler
+   .thumb_set DMA1_Stream7_IRQHandler,Default_Handler
+
+   .weak      FMC_IRQHandler
+   .thumb_set FMC_IRQHandler,Default_Handler
+
+   .weak      SDMMC1_IRQHandler
+   .thumb_set SDMMC1_IRQHandler,Default_Handler
+
+   .weak      TIM5_IRQHandler
+   .thumb_set TIM5_IRQHandler,Default_Handler
+
+   .weak      SPI3_IRQHandler
+   .thumb_set SPI3_IRQHandler,Default_Handler
+
+   .weak      UART4_IRQHandler
+   .thumb_set UART4_IRQHandler,Default_Handler
+
+   .weak      UART5_IRQHandler
+   .thumb_set UART5_IRQHandler,Default_Handler
+
+   .weak      TIM6_DAC_IRQHandler
+   .thumb_set TIM6_DAC_IRQHandler,Default_Handler
+
+   .weak      TIM7_IRQHandler
+   .thumb_set TIM7_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream0_IRQHandler
+   .thumb_set DMA2_Stream0_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream1_IRQHandler
+   .thumb_set DMA2_Stream1_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream2_IRQHandler
+   .thumb_set DMA2_Stream2_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream3_IRQHandler
+   .thumb_set DMA2_Stream3_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream4_IRQHandler
+   .thumb_set DMA2_Stream4_IRQHandler,Default_Handler
+
+   .weak      ETH_IRQHandler
+   .thumb_set ETH_IRQHandler,Default_Handler
+
+   .weak      ETH_WKUP_IRQHandler
+   .thumb_set ETH_WKUP_IRQHandler,Default_Handler
+
+   .weak      FDCAN_CAL_IRQHandler
+   .thumb_set FDCAN_CAL_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream5_IRQHandler
+   .thumb_set DMA2_Stream5_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream6_IRQHandler
+   .thumb_set DMA2_Stream6_IRQHandler,Default_Handler
+
+   .weak      DMA2_Stream7_IRQHandler
+   .thumb_set DMA2_Stream7_IRQHandler,Default_Handler
+
+   .weak      USART6_IRQHandler
+   .thumb_set USART6_IRQHandler,Default_Handler
+
+   .weak      I2C3_EV_IRQHandler
+   .thumb_set I2C3_EV_IRQHandler,Default_Handler
+
+   .weak      I2C3_ER_IRQHandler
+   .thumb_set I2C3_ER_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_EP1_OUT_IRQHandler
+   .thumb_set OTG_HS_EP1_OUT_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_EP1_IN_IRQHandler
+   .thumb_set OTG_HS_EP1_IN_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_WKUP_IRQHandler
+   .thumb_set OTG_HS_WKUP_IRQHandler,Default_Handler
+
+   .weak      OTG_HS_IRQHandler
+   .thumb_set OTG_HS_IRQHandler,Default_Handler
+
+   .weak      DCMI_PSSI_IRQHandler
+   .thumb_set DCMI_PSSI_IRQHandler,Default_Handler
+
+   .weak      RNG_IRQHandler
+   .thumb_set RNG_IRQHandler,Default_Handler
+
+   .weak      FPU_IRQHandler
+   .thumb_set FPU_IRQHandler,Default_Handler
+
+   .weak      UART7_IRQHandler
+   .thumb_set UART7_IRQHandler,Default_Handler
+
+   .weak      UART8_IRQHandler
+   .thumb_set UART8_IRQHandler,Default_Handler
+
+   .weak      SPI4_IRQHandler
+   .thumb_set SPI4_IRQHandler,Default_Handler
+
+   .weak      SPI5_IRQHandler
+   .thumb_set SPI5_IRQHandler,Default_Handler
+
+   .weak      SPI6_IRQHandler
+   .thumb_set SPI6_IRQHandler,Default_Handler
+
+   .weak      SAI1_IRQHandler
+   .thumb_set SAI1_IRQHandler,Default_Handler
+
+   .weak      LTDC_IRQHandler
+   .thumb_set LTDC_IRQHandler,Default_Handler
+
+   .weak      LTDC_ER_IRQHandler
+   .thumb_set LTDC_ER_IRQHandler,Default_Handler
+
+   .weak      DMA2D_IRQHandler
+   .thumb_set DMA2D_IRQHandler,Default_Handler
+
+   .weak      OCTOSPI1_IRQHandler
+   .thumb_set OCTOSPI1_IRQHandler,Default_Handler
+
+   .weak      LPTIM1_IRQHandler
+   .thumb_set LPTIM1_IRQHandler,Default_Handler
+
+   .weak      CEC_IRQHandler
+   .thumb_set CEC_IRQHandler,Default_Handler
+
+   .weak      I2C4_EV_IRQHandler
+   .thumb_set I2C4_EV_IRQHandler,Default_Handler
+
+   .weak      I2C4_ER_IRQHandler
+   .thumb_set I2C4_ER_IRQHandler,Default_Handler
+
+   .weak      SPDIF_RX_IRQHandler
+   .thumb_set SPDIF_RX_IRQHandler,Default_Handler
+
+   .weak      DMAMUX1_OVR_IRQHandler
+   .thumb_set DMAMUX1_OVR_IRQHandler,Default_Handler
+
+   .weak      DFSDM1_FLT0_IRQHandler
+   .thumb_set DFSDM1_FLT0_IRQHandler,Default_Handler
+
+   .weak      DFSDM1_FLT1_IRQHandler
+   .thumb_set DFSDM1_FLT1_IRQHandler,Default_Handler
+
+   .weak      DFSDM1_FLT2_IRQHandler
+   .thumb_set DFSDM1_FLT2_IRQHandler,Default_Handler
+
+   .weak      DFSDM1_FLT3_IRQHandler
+   .thumb_set DFSDM1_FLT3_IRQHandler,Default_Handler
+
+   .weak      SWPMI1_IRQHandler
+   .thumb_set SWPMI1_IRQHandler,Default_Handler
+
+   .weak      TIM15_IRQHandler
+   .thumb_set TIM15_IRQHandler,Default_Handler
+
+   .weak      TIM16_IRQHandler
+   .thumb_set TIM16_IRQHandler,Default_Handler
+
+   .weak      TIM17_IRQHandler
+   .thumb_set TIM17_IRQHandler,Default_Handler
+
+   .weak      MDIOS_WKUP_IRQHandler
+   .thumb_set MDIOS_WKUP_IRQHandler,Default_Handler
+
+   .weak      MDIOS_IRQHandler
+   .thumb_set MDIOS_IRQHandler,Default_Handler
+
+   .weak      MDMA_IRQHandler
+   .thumb_set MDMA_IRQHandler,Default_Handler
+
+   .weak      SDMMC2_IRQHandler
+   .thumb_set SDMMC2_IRQHandler,Default_Handler
+
+   .weak      HSEM1_IRQHandler
+   .thumb_set HSEM1_IRQHandler,Default_Handler
+
+   .weak      ADC3_IRQHandler
+   .thumb_set ADC3_IRQHandler,Default_Handler
+
+   .weak      DMAMUX2_OVR_IRQHandler
+   .thumb_set DMAMUX2_OVR_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel0_IRQHandler
+   .thumb_set BDMA_Channel0_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel1_IRQHandler
+   .thumb_set BDMA_Channel1_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel2_IRQHandler
+   .thumb_set BDMA_Channel2_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel3_IRQHandler
+   .thumb_set BDMA_Channel3_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel4_IRQHandler
+   .thumb_set BDMA_Channel4_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel5_IRQHandler
+   .thumb_set BDMA_Channel5_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel6_IRQHandler
+   .thumb_set BDMA_Channel6_IRQHandler,Default_Handler
+
+   .weak      BDMA_Channel7_IRQHandler
+   .thumb_set BDMA_Channel7_IRQHandler,Default_Handler
+
+   .weak      COMP1_IRQHandler
+   .thumb_set COMP1_IRQHandler,Default_Handler
+
+   .weak      LPTIM2_IRQHandler
+   .thumb_set LPTIM2_IRQHandler,Default_Handler
+
+   .weak      LPTIM3_IRQHandler
+   .thumb_set LPTIM3_IRQHandler,Default_Handler
+
+   .weak      LPTIM4_IRQHandler
+   .thumb_set LPTIM4_IRQHandler,Default_Handler
+
+   .weak      LPTIM5_IRQHandler
+   .thumb_set LPTIM5_IRQHandler,Default_Handler
+
+   .weak      LPUART1_IRQHandler
+   .thumb_set LPUART1_IRQHandler,Default_Handler
+
+   .weak      CRS_IRQHandler
+   .thumb_set CRS_IRQHandler,Default_Handler
+
+   .weak      ECC_IRQHandler
+   .thumb_set ECC_IRQHandler,Default_Handler
+
+   .weak      SAI4_IRQHandler
+   .thumb_set SAI4_IRQHandler,Default_Handler
+
+   .weak      DTS_IRQHandler
+   .thumb_set DTS_IRQHandler,Default_Handler
+
+   .weak      WAKEUP_PIN_IRQHandler
+   .thumb_set WAKEUP_PIN_IRQHandler,Default_Handler
+
+   .weak      OCTOSPI2_IRQHandler
+   .thumb_set OCTOSPI2_IRQHandler,Default_Handler
+
+   .weak      FMAC_IRQHandler
+   .thumb_set FMAC_IRQHandler,Default_Handler
+
+   .weak      CORDIC_IRQHandler
+   .thumb_set CORDIC_IRQHandler,Default_Handler
+
+   .weak      UART9_IRQHandler
+   .thumb_set UART9_IRQHandler,Default_Handler
+
+   .weak      USART10_IRQHandler
+   .thumb_set USART10_IRQHandler,Default_Handler
+
+   .weak      I2C5_EV_IRQHandler
+   .thumb_set I2C5_EV_IRQHandler,Default_Handler
+
+   .weak      I2C5_ER_IRQHandler
+   .thumb_set I2C5_ER_IRQHandler,Default_Handler
+
+   .weak      FDCAN3_IT0_IRQHandler
+   .thumb_set FDCAN3_IT0_IRQHandler,Default_Handler
+
+   .weak      FDCAN3_IT1_IRQHandler
+   .thumb_set FDCAN3_IT1_IRQHandler,Default_Handler
+
+   .weak      TIM23_IRQHandler
+   .thumb_set TIM23_IRQHandler,Default_Handler
+
+   .weak      TIM24_IRQHandler
+   .thumb_set TIM24_IRQHandler,Default_Handler
+
+

--- a/boards/remora_STM32H723VG.json
+++ b/boards/remora_STM32H723VG.json
@@ -1,0 +1,38 @@
+{
+    "build": {
+      "core": "stm32",
+      "cpu": "cortex-m7",
+      "extra_flags": "-DSTM32H7xx -DSTM32H723xx",
+      "f_cpu": "550000000L",
+      "mcu": "stm32h723vgt6",
+      "product_line": "STM32H723xx",
+      "variant": "REMORA_H723VG"
+    },
+    "debug": {
+      "jlink_device": "STM32H723VG",
+      "openocd_target": "stm32h7x",
+      "svd_path": "STM32H7x3.svd"
+    },
+    "frameworks": [
+      "stm32cube"
+    ],
+    "name": "STM32H723VG (564k RAM. 1024k Flash)",
+    "upload": {
+      "disable_flushing": false,
+      "maximum_ram_size": 577536,
+      "maximum_size": 1048576,
+      "protocol": "stlink",
+      "protocols": [
+        "stlink",
+        "dfu",
+        "jlink",
+        "cmsis-dap"
+      ],
+      "offset_address": "0x8000000",
+      "require_upload_port": true,
+      "use_1200bps_touch": false,
+      "wait_for_upload_port": false
+    },
+    "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32h723vg.html",
+    "vendor": "ST"
+  }

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,6 +1,29 @@
 ; PlatformIO Project Configuration File
 ;
 ; https://docs.platformio.org/page/projectconf.html
+;
+; ── Board overview ───────────────────────────────────────────────────────────
+;
+;  SKR3 (STM32H743VI, 480 MHz, HSE 25 MHz)
+;    Comms:  SPI1  PA4(CS) PA5(SCK) PA6(MISO) PA7(MOSI)   EXTI4
+;    SD:     SDMMC1  PC8-PC12 + PD2                        [default]
+;    SD:     SPI1  PA4(CS) PA5(SCK) PA6(MISO) PA7(MOSI)   [SD_SPI dev only]
+;    UART:   USART1  PA9(TX) PA10(RX)
+;
+;  Scylla (STM32H723VG, 550 MHz, HSE 25 MHz)
+;    Comms:  SPI2  PB12(CS) PB13(SCK) PB14(MISO) PB15(MOSI)  EXTI15_10
+;    SD:     SDMMC1  PC8-PC12 + PD2
+;    UART:   USART3  PD8(TX) PD9(RX)
+;
+;  Manta M8P V2.0 (STM32H723VG, 550 MHz, HSE 25 MHz)
+;    Comms:  SPI3  PA15(CS) PC10(SCK) PC11(MISO) PC12(MOSI)  EXTI15_10
+;    SD:     SPI2  PB12(CS) PB13(SCK) PB14(MISO) PB15(MOSI)  SD_SPI
+;    UART:   USART3  PD8(TX) PD9(RX)
+;
+; ── SD transport ─────────────────────────────────────────────────────────────
+;  -D SD_SPI → FATFS/SPI  (STM32H7_SPI_SDcard class)
+;  no define  → FATFS/SDIO (STM32H7_SDIO class)
+; ─────────────────────────────────────────────────────────────────────────────
 
 [platformio]
 include_dir  = Inc
@@ -8,21 +31,14 @@ src_dir      = Src
 boards_dir   = boards
 default_envs = SKR3
 
-; ─────────────────────────────────────────────
-; Shared build settings — no board-specific
-; flags, no src filter
-; ─────────────────────────────────────────────
-[STM32H743VI]
-platform       = ststm32
-framework      = stm32cube
-lib_archive    = no
-lib_ldf_mode   = off
-
+; ─────────────────────────────────────────────────────────────────────────────
+; Common build settings
+; ─────────────────────────────────────────────────────────────────────────────
+[common]
 build_flags =
     -I FATFS/App
     -I FATFS/Target
     -I Middlewares/Third_Party/FatFs/src
-    -D TARGET_STM32H7_480MHZ
 
 lib_deps =
     FATFS/App
@@ -33,13 +49,39 @@ lib_deps =
 lib_extra_dirs =
     Middlewares/Third_Party/FatFs
 
-; ─────────────────────────────────────────────
-; SKR 3 board-specific flags
-; SPI1 on PA4-PA7, CS IRQ on EXTI4
-; ─────────────────────────────────────────────
+; ─────────────────────────────────────────────────────────────────────────────
+; PlatformIO environment base
+; ─────────────────────────────────────────────────────────────────────────────
+[env]
+platform       = ststm32
+framework      = stm32cube
+lib_archive    = no
+lib_ldf_mode   = off
+
+; ─────────────────────────────────────────────────────────────────────────────
+; Silicon base configs
+; ─────────────────────────────────────────────────────────────────────────────
+[STM32H743VI]
+board = remora_STM32H743VI
+build_flags =
+    ${common.build_flags}
+    -D TARGET_STM32H7_480MHZ
+lib_deps       = ${common.lib_deps}
+lib_extra_dirs = ${common.lib_extra_dirs}
+
+[STM32H723VG]
+board = remora_STM32H723VG
+build_flags =
+    ${common.build_flags}
+    -D TARGET_STM32H7_550MHZ
+lib_deps       = ${common.lib_deps}
+lib_extra_dirs = ${common.lib_extra_dirs}
+
+; ─────────────────────────────────────────────────────────────────────────────
+; SKR3 flags — SDMMC1 onboard SD (default)
+; ─────────────────────────────────────────────────────────────────────────────
 [flags_skr3]
 build_flags =
-    -I Src/remora-hal  
     -D SPI_MOSI="\"PA_7\""
     -D SPI_MISO="\"PA_6\""
     -D SPI_CLK="\"PA_5\""
@@ -53,86 +95,247 @@ build_flags =
     -D REMORA_SD_D1="\"PC_9\""
     -D REMORA_SD_D2="\"PC_10\""
     -D REMORA_SD_D3="\"PC_11\""
+    -I FATFS/SDIO
+    -I Src/remora-hal
 
-    -I FATFS/SDIO 
-
-[flags_skr3_test]
+; ─────────────────────────────────────────────────────────────────────────────
+; SKR3 flags — EXP2 SPI SD (development / bring-up only)
+; SPI1 is shared with comms — only use without comms active
+; ─────────────────────────────────────────────────────────────────────────────
+[flags_skr3_sdspi]
 build_flags =
-    -I Src/remora-hal  
     -D SPI_MOSI="\"PA_7\""
     -D SPI_MISO="\"PA_6\""
     -D SPI_CLK="\"PA_5\""
     -D SPI_CS="\"PA_4\""
     -D SPI_CS_IRQ=EXTI4_IRQn
+    -D REMORA_UART_TX="\"PA_9\""
+    -D REMORA_UART_RX="\"PA_10\""
     -D SD_SPI
-    -I FATFS/SPI 
+    -D SD_MOSI="\"PA_7\""
+    -D SD_MISO="\"PA_6\""
+    -D SD_CLK="\"PA_5\""
+    -D SD_CS="\"PA_4\""
+    -I FATFS/SPI
+    -I Src/remora-hal
+
+; ─────────────────────────────────────────────────────────────────────────────
+; Scylla flags — SDMMC1 onboard SD, SPI2 comms
+; ─────────────────────────────────────────────────────────────────────────────
+[flags_scylla]
+build_flags =
+    -D SPI_MOSI="\"PB_15\""
+    -D SPI_MISO="\"PB_14\""
+    -D SPI_CLK="\"PB_13\""
+    -D SPI_CS="\"PB_12\""
+    -D SPI_CS_IRQ=EXTI15_10_IRQn
+    -D REMORA_UART_TX="\"PD_8\""
+    -D REMORA_UART_RX="\"PD_9\""
+    -D REMORA_SD_CMD="\"PD_2\""
+    -D REMORA_SD_CLK="\"PC_12\""
+    -D REMORA_SD_D0="\"PC_8\""
+    -D REMORA_SD_D1="\"PC_9\""
+    -D REMORA_SD_D2="\"PC_10\""
+    -D REMORA_SD_D3="\"PC_11\""
+    -I FATFS/SDIO
+    -I Src/remora-hal
+
+; ─────────────────────────────────────────────────────────────────────────────
+; Manta M8P V2.0 flags — SPI2 SD card, SPI3 comms
+; ─────────────────────────────────────────────────────────────────────────────
+[flags_manta_m8p_v2]
+build_flags =
+    -D SPI_MOSI="\"PC_12\""
+    -D SPI_MISO="\"PC_11\""
+    -D SPI_CLK="\"PC_10\""
+    -D SPI_CS="\"PA_15\""
+    -D SPI_CS_IRQ=EXTI15_10_IRQn
+    -D REMORA_UART_TX="\"PD_8\""
+    -D REMORA_UART_RX="\"PD_9\""
+    -D SD_SPI
     -D SD_MOSI="\"PB_15\""
     -D SD_MISO="\"PB_14\""
     -D SD_CLK="\"PB_13\""
     -D SD_CS="\"PB_12\""
+    -I FATFS/SPI
+    -I Src/remora-hal
 
-; ─────────────────────────────────────────────
-; SKR 3 src filter — all modules included;
-; comment out any not needed for your build
-; ─────────────────────────────────────────────
-[src_filter_skr3]
+; ─────────────────────────────────────────────────────────────────────────────
+; Common source filter
+; ─────────────────────────────────────────────────────────────────────────────
+[src_filter_common]
 filter =
     +<*>
-	-<remora-core/modules/>
-	+<remora-core/modules/*.cpp>
-	+<remora-core/modules/*.h>
+    -<remora-core/modules/>
+    +<remora-core/modules/*.cpp>
+    +<remora-core/modules/*.h>
     +<remora-core/modules/blink/**>
-	+<remora-core/modules/comms/**>
+    +<remora-core/modules/comms/**>
     +<remora-core/modules/digitalPin/**>
-	+<remora-core/modules/resetPin/**>
-	+<remora-core/modules/sigmaDelta/**>
-	+<remora-core/modules/stepgen/**>
+    +<remora-core/modules/resetPin/**>
+    +<remora-core/modules/sigmaDelta/**>
+    +<remora-core/modules/stepgen/**>
     +<remora-core/modules/temperature/**>
-	+<remora-core/modules/tmc/**>
+    +<remora-core/modules/tmc/**>
 
-; ─────────────────────────────────────────────
-; SKR 3 — direct flash via ST-Link
-; ─────────────────────────────────────────────
+; ─────────────────────────────────────────────────────────────────────────────
+; SKR3 — onboard SDMMC1, direct flash
+; ─────────────────────────────────────────────────────────────────────────────
 [env:SKR3]
 extends              = STM32H743VI
-board                = remora_STM32H743VI
 board_build.ldscript = STM32H743VITX_FLASH.ld
 upload_protocol      = stlink
 debug_tool           = stlink
 build_flags          = ${STM32H743VI.build_flags}
                        ${flags_skr3.build_flags}
-build_src_filter     = ${src_filter_skr3.filter}
+build_src_filter     = ${src_filter_common.filter}
 lib_deps             = ${STM32H743VI.lib_deps}
                        FATFS/SDIO
 
-; ─────────────────────────────────────────────
-; SKR 3 — with BTT bootloader offset
-; ─────────────────────────────────────────────
+; ─────────────────────────────────────────────────────────────────────────────
+; SKR3 — onboard SDMMC1, BTT bootloader
+; ─────────────────────────────────────────────────────────────────────────────
 [env:SKR3_BL]
 extends              = STM32H743VI
-board                = remora_STM32H743VI
 board_build.ldscript = STM32H743VITX_BL_FLASH.ld
 upload_protocol      = stlink
 debug_tool           = stlink
 build_flags          = ${STM32H743VI.build_flags}
                        ${flags_skr3.build_flags}
                        -D HAS_BOOTLOADER=1
-build_src_filter     = ${src_filter_skr3.filter}
-                       ${flags_skr3_test.build_flags}
+build_src_filter     = ${src_filter_common.filter}
 lib_deps             = ${STM32H743VI.lib_deps}
                        FATFS/SDIO
 
-; ─────────────────────────────────────────────
-; SKR 3 — direct flash via ST-Link
-; ─────────────────────────────────────────────
-[env:SKR3_test]
+; ─────────────────────────────────────────────────────────────────────────────
+; SKR3 — EXP2 SPI SD, direct flash (development / bring-up only)
+; ─────────────────────────────────────────────────────────────────────────────
+[env:SKR3_SPI_SD]
 extends              = STM32H743VI
-board                = remora_STM32H743VI
 board_build.ldscript = STM32H743VITX_FLASH.ld
 upload_protocol      = stlink
 debug_tool           = stlink
 build_flags          = ${STM32H743VI.build_flags}
-                       ${flags_skr3_test.build_flags}
-build_src_filter     = ${src_filter_skr3.filter}
+                       ${flags_skr3_sdspi.build_flags}
+build_src_filter     = ${src_filter_common.filter}
 lib_deps             = ${STM32H743VI.lib_deps}
                        FATFS/SPI
+
+; ─────────────────────────────────────────────────────────────────────────────
+; Scylla — SDMMC1 onboard SD, SPI2 comms, direct flash
+; ─────────────────────────────────────────────────────────────────────────────
+[env:Scylla]
+extends              = STM32H723VG
+board_build.ldscript = STM32H723VGTX_FLASH.ld
+upload_protocol      = stlink
+debug_tool           = stlink
+build_flags          = ${STM32H723VG.build_flags}
+                       ${flags_scylla.build_flags}
+build_src_filter     = ${src_filter_common.filter}
+lib_deps             = ${STM32H723VG.lib_deps}
+                       FATFS/SDIO
+
+; ─────────────────────────────────────────────────────────────────────────────
+; Scylla — SDMMC1 onboard SD, SPI2 comms, BTT bootloader
+; ─────────────────────────────────────────────────────────────────────────────
+[env:Scylla_BL]
+extends              = STM32H723VG
+board_build.ldscript = STM32H723VGTX_BL_FLASH.ld
+upload_protocol      = stlink
+debug_tool           = stlink
+build_flags          = ${STM32H723VG.build_flags}
+                       ${flags_scylla.build_flags}
+                       -D HAS_BOOTLOADER=1
+build_src_filter     = ${src_filter_common.filter}
+lib_deps             = ${STM32H723VG.lib_deps}
+                       FATFS/SDIO
+
+; ─────────────────────────────────────────────────────────────────────────────
+; Manta M8P V2.0 — SPI2 SD, SPI3 comms, direct flash
+; ─────────────────────────────────────────────────────────────────────────────
+[env:Manta_M8P_V2]
+extends              = STM32H723VG
+board_build.ldscript = STM32H723VGTX_FLASH.ld
+upload_protocol      = stlink
+debug_tool           = stlink
+build_flags          = ${STM32H723VG.build_flags}
+                       ${flags_manta_m8p_v2.build_flags}
+build_src_filter     = ${src_filter_common.filter}
+lib_deps             = ${STM32H723VG.lib_deps}
+                       FATFS/SPI
+
+; ─────────────────────────────────────────────────────────────────────────────
+; Manta M8P V2.0 — SPI2 SD, SPI3 comms, BTT bootloader
+; ─────────────────────────────────────────────────────────────────────────────
+[env:Manta_M8P_V2_BL]
+extends              = STM32H723VG
+board_build.ldscript = STM32H723VGTX_BL_FLASH.ld
+upload_protocol      = stlink
+debug_tool           = stlink
+build_flags          = ${STM32H723VG.build_flags}
+                       ${flags_manta_m8p_v2.build_flags}
+                       -D HAS_BOOTLOADER=1
+build_src_filter     = ${src_filter_common.filter}
+lib_deps             = ${STM32H723VG.lib_deps}
+                       FATFS/SPI
+
+; ─────────────────────────────────────────────────────────────────────────────
+; ST Nucleo H743ZI2 — development board (8 MHz HSE via STLink MCO)
+; ─────────────────────────────────────────────────────────────────────────────
+[env:nucleo_h743]
+board                = nucleo_h743zi
+board_build.ldscript = STM32H743ZITX_FLASH.ld
+upload_protocol      = stlink
+debug_tool           = stlink
+build_flags =
+    ${common.build_flags}
+    -D NUCLEO_H743
+    -D SPI_MOSI="\"PA_7\""
+    -D SPI_MISO="\"PA_6\""
+    -D SPI_CLK="\"PA_5\""
+    -D SPI_CS="\"PA_4\""
+    -D SPI_CS_IRQ=EXTI4_IRQn
+    -D REMORA_UART_TX="\"PA_9\""
+    -D REMORA_UART_RX="\"PA_10\""
+    -D REMORA_SD_CMD="\"PD_2\""
+    -D REMORA_SD_CLK="\"PC_12\""
+    -D REMORA_SD_D0="\"PC_8\""
+    -D REMORA_SD_D1="\"PC_9\""
+    -D REMORA_SD_D2="\"PC_10\""
+    -D REMORA_SD_D3="\"PC_11\""
+    -I FATFS/SDIO
+    -I Src/remora-hal
+lib_deps       = ${common.lib_deps}
+                 FATFS/SDIO
+lib_extra_dirs = ${common.lib_extra_dirs}
+
+; ─────────────────────────────────────────────────────────────────────────────
+; ST Nucleo H723ZG — development board (8 MHz HSE via STLink MCO)
+; Pin layout matches Scylla/Manta for easy cross-testing
+; ─────────────────────────────────────────────────────────────────────────────
+[env:nucleo_h723]
+board                = nucleo_h723zg
+board_build.ldscript = STM32H723VGTX_FLASH.ld
+upload_protocol      = stlink
+debug_tool           = stlink
+build_flags =
+    ${common.build_flags}
+    -D NUCLEO_H723
+    -D SPI_MOSI="\"PB_15\""
+    -D SPI_MISO="\"PB_14\""
+    -D SPI_CLK="\"PB_13\""
+    -D SPI_CS="\"PB_12\""
+    -D SPI_CS_IRQ=EXTI15_10_IRQn
+    -D REMORA_UART_TX="\"PD_8\""
+    -D REMORA_UART_RX="\"PD_9\""
+    -D REMORA_SD_CMD="\"PD_2\""
+    -D REMORA_SD_CLK="\"PC_12\""
+    -D REMORA_SD_D0="\"PC_8\""
+    -D REMORA_SD_D1="\"PC_9\""
+    -D REMORA_SD_D2="\"PC_10\""
+    -D REMORA_SD_D3="\"PC_11\""
+    -I FATFS/SDIO
+    -I Src/remora-hal
+lib_deps       = ${common.lib_deps}
+                 FATFS/SDIO
+lib_extra_dirs = ${common.lib_extra_dirs}


### PR DESCRIPTION
feat: add STM32H723 support, Scylla and Manta M8P V2.0 board configs,
      and complete HAL class refactor for UART, SDIO and SPI SD card

── HAL classes (Src/remora-hal/) ───────────────────────────────────────

STM32H7_UART
  - New class replacing MX_USART1_UART_Init() in main.cpp
  - Resolves UART peripheral via pinmap (portAndPinToPinName)
  - Owns HAL handle; sets g_uart global for printf retargeting
  - Adds H7-specific fields: ClockPrescaler, OneBitSampling,
    AdvFeatureInit, FIFO threshold — fixes hardfault on usartdiv
  - UART clock (USART1/USART3) configured via HAL_UART_MspInit in
    stm32h7xx_hal_msp.c (existing mechanism preserved)

STM32H7_SDIO
  - New class replacing MX_SDMMC1_SD_Init() in main.cpp
  - Resolves SDMMC peripheral instance from pin strings via pinmap
  - hsd zero-initialised (hsd{}) so HAL_SD_Init sees
    HAL_SD_STATE_RESET and fires MspInit correctly
  - HAL_SD_MspInit() overridden in STM32H7_SDIO.cpp via g_sdio
    global pointer → mspInit() callback pattern (mirrors g_sdCard)
  - mspInit() configures: SDMMC clock to RCC_SDMMCCLKSOURCE_PLL
    (overrides PLL2 set in SystemClock_Config), peripheral clock
    enable, GPIO via pinmap-resolved Pin objects, NVIC
  - hsd1 global declared in STM32H7_SDIO.cpp; synced from hsd
    before MX_FATFS_Init() so bsp_driver_sd.c and stm32h7xx_it.c
    resolve correctly
  - SDMMC2 support guarded with #if defined(SDMMC2)

STM32H7_SPI_SDcard
  - hspi1 now declared in STM32H7_SPI_SDcard.cpp (was main.cpp)
  - g_sdCard set in constructor for bsp_driver_sd_spi.cpp
  - MX_GPIO_SD_Init / MX_SPI1_SD_Init removed from main.cpp

── FatFs filesystem responsibility ─────────────────────────────────────

  f_mount removed from STM32H7_SPI_SDcard::init() and
  STM32H7_SDIO::init(). JsonConfigHandler::readConfigFromSD()
  owns the filesystem lifecycle (f_mount with opt=0 already present).
  MX_FATFS_Init() remains in the hardware classes — it only registers
  the FatFs disk driver, it does not access the card.

── sd_spi.c / sd_spi_test.c ────────────────────────────────────────────

  sd_spi.c and sd_spi_test.c removed. All raw SPI SD protocol
  (CMD0→CMD8→ACMD41→CMD58→CMD16→CMD9, CMD17, CMD24, fclkSlow/Fast,
  csAssert/Deassert, spiXchg, sdCmd) now lives as private methods
  of STM32H7_SPI_SDcard. bsp_driver_sd_spi.cpp calls through
  g_sdCard pointer; renamed from .c to .cpp to avoid C/C++ linkage
  conflict when calling class methods.

── main.cpp ────────────────────────────────────────────────────────────

  - MX_USART1_UART_Init, MX_SDMMC1_SD_Init, MX_GPIO_SD_Init,
    MX_SPI1_SD_Init, MX_GPIO_Init removed
  - hsd1, huart1 globals removed (owned by HAL classes)
  - SD init block: #ifdef SD_SPI → STM32H7_SPI_SDcard,
    else → STM32H7_SDIO
  - SystemClock_Config() now handles all four variants:
      STM32H743xx + NUCLEO_H743  8 MHz HSE  480 MHz
      STM32H743xx                25 MHz HSE  480 MHz  (SKR3)
      STM32H723xx + NUCLEO_H723  8 MHz HSE  550 MHz
      STM32H723xx                25 MHz HSE  550 MHz  (Scylla, Manta)
  - PeriphCommonClock_Config() removed; peripheral clocks set
    inline in SystemClock_Config() following scylla1 pattern
  - MPU_Config() moved before HAL_Init() per scylla1
  - FLASH_LATENCY_3 used for H723 (was FLASH_LATENCY_4 for H743)
  - extern SD_HandleTypeDef hsd1 declared at top of main.cpp

── STM32H723 support ───────────────────────────────────────────────────

  boards/remora_STM32H723VG.json
    New board definition: STM32H723VGTx, 550 MHz, 1 MB flash,
    576 KB RAM, stlink upload

  STM32H723VGTX_FLASH.ld     (from scylla1, unchanged)
  STM32H723VGTX_BL_FLASH.ld  (from scylla1, unchanged)
    Single-bank 1 MB flash; BL offset at 0x08020000 (128 KiB)

── platformio.ini ──────────────────────────────────────────────────────

  Board flag sections added:
    [flags_skr3]          SDMMC1 SD, SPI1 comms, USART1
    [flags_skr3_sdspi]    SPI1 SD (dev only), SPI1 comms, USART1
    [flags_scylla]        SDMMC1 SD, SPI2 comms, USART3
    [flags_manta_m8p_v2]  SPI2 SD, SPI3 comms, USART3

  Environments:
    SKR3, SKR3_BL           H743, SDMMC1, direct/BL flash
    SKR3_SPI_SD             H743, SPI SD on EXP2, dev only
    Scylla, Scylla_BL       H723, SDMMC1, SPI2 comms
    Manta_M8P_V2,
    Manta_M8P_V2_BL         H723, SPI2 SD, SPI3 comms
    nucleo_h743             H743 Nucleo dev board
    nucleo_h723             H723 Nucleo dev board

  SD transport selected per environment:
    -D SD_SPI + FATFS/SPI   → STM32H7_SPI_SDcard (Manta, SKR3_SPI_SD)
    no define + FATFS/SDIO  → STM32H7_SDIO       (SKR3, Scylla)

── irq_handlers.h ──────────────────────────────────────────────────────

  CS IRQ handler now selected at compile time via SPI_CS_IRQ:
    EXTI4_IRQn       → EXTI4_IRQHandler      GPIO_PIN_4  (SKR3)
    EXTI15_10_IRQn   → EXTI15_10_IRQHandler  GPIO_PIN_15 (Scylla, Manta)
  #error catches unsupported EXTI groups at build time